### PR TITLE
Prevent Potential Crash at Line 246 in Form1.cs

### DIFF
--- a/Kindle Cover Fixer/Form1.Designer.cs
+++ b/Kindle Cover Fixer/Form1.Designer.cs
@@ -189,7 +189,7 @@
             transferButton.Name = "transferButton";
             transferButton.Size = new Size(164, 23);
             transferButton.TabIndex = 0;
-            transferButton.Text = "Transfer Covers to Kindle Scribe";
+            transferButton.Text = "Transfer covers to Kindle Scribe";
             toolTip1.SetToolTip(transferButton, "Send the generated covers to the Kindle");
             transferButton.UseVisualStyleBackColor = true;
             transferButton.Visible = false;

--- a/Kindle Cover Fixer/Form1.cs
+++ b/Kindle Cover Fixer/Form1.cs
@@ -243,7 +243,10 @@ namespace Kindle_Cover_Fixer
                                         image = file;
                                     }
                                 }
-                               File.Copy(image, OutputDir + @"\" + "thumbnail_" + uuid + "_EBOK_portrait.jpg");
+                                if (image != string.Empty) 
+                                {
+                                   File.Copy(image, OutputDir + @"\" + "thumbnail_" + uuid + "_EBOK_portrait.jpg");
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Prevents a potential crash during cover generation when there is no cover present for a book in the Calibre library by checking to see if the "image" string (initialized at line 223) is still empty. If the string has been modified, confirming the existence of the cover image, said image will be copied over to the OUTPUT directory.  

Also fixes a trivial capitalization error present in the text of the transfer button.